### PR TITLE
Fix import for recent Python3 versions

### DIFF
--- a/cashier/__init__.py
+++ b/cashier/__init__.py
@@ -4,7 +4,7 @@ import errno
 import sqlite3
 from time import time
 try:
-    from pickle import loads, dumps
+    from cPickle import loads, dumps
 except ImportError:
     from pickle import loads, dumps
 try:

--- a/cashier/__init__.py
+++ b/cashier/__init__.py
@@ -8,9 +8,12 @@ try:
 except ImportError:
     from pickle import loads, dumps
 try:
-    from _dummy_thread import get_ident
+    from _thread import get_ident
 except ImportError:
-    from dummy_thread import get_ident
+    try:
+        from _dummy_thread import get_ident
+    except ImportError:
+        from dummy_thread import get_ident
 from hashlib import md5
 
 meta_data = {


### PR DESCRIPTION
_dummy_thread have been removed in Python 3.8 - so we try importing _thread first.

Tested with Python 3.11.4.

Fixes: https://github.com/atmb4u/cashier/issues/12